### PR TITLE
Remove unused .empty CSS rule

### DIFF
--- a/src/Images/Carousel.svelte
+++ b/src/Images/Carousel.svelte
@@ -103,9 +103,6 @@
     stroke: currentcolor;
     stroke-width: 0;
   }
-  .empty {
-    width: 100px;
-  }
   @media (max-width: 800px) {
     :global(.carousel img) {
       max-width: 75vw;


### PR DESCRIPTION
This PR fixes the following error by removing the unused CSS rule.

```
┌───────────────────────────────┐
│ built client with 28 warnings │
└───────────────────────────────┘
> /home/runner/work/koj/koj/node_modules/svelte-images/src/Images/Carousel.svelte
Unused CSS selector ".empty"
105:     stroke-width: 0;
106:   }
107:   .empty {
       ^
108:     width: 100px;
109:   }
```